### PR TITLE
Added conversion toList() for map()

### DIFF
--- a/lib/src/node.dart
+++ b/lib/src/node.dart
@@ -26,7 +26,7 @@ class Node {
     if (plane != null) { node.plane = plane.clone(); }
     if (front != null) { node.front = front.clone(); }
     if (back != null) { node.back = back.clone(); }
-    node.polygons = polygons.map((p) => p.clone());
+    node.polygons = polygons.map((p) => p.clone()).toList();
     return node;
   }
 

--- a/lib/src/polygon.dart
+++ b/lib/src/polygon.dart
@@ -19,7 +19,7 @@ class Polygon {
     this.plane = new Plane.fromPoints(vertices[0].pos, vertices[1].pos, vertices[2].pos);
   }
 
-  clone() =>  new Polygon(vertices.map((v) => v.clone()), shared);
+  clone() =>  new Polygon(vertices.map((v) => v.clone()).toList(), shared);
 
   flip() {
     var flipped = [];


### PR DESCRIPTION
It's now necessary to call toList() on a map() to convert it into a List. This pull request fixes two cases where this needed to happen.
